### PR TITLE
fix field owner management in case of mixed update/apply operations

### DIFF
--- a/pkg/component/ssa.go
+++ b/pkg/component/ssa.go
@@ -35,7 +35,11 @@ func replaceFieldManager(managedFields []metav1.ManagedFieldsEntry, managerPrefi
 		if entry == managerEntry {
 			continue
 		}
-		if !slices.Any(managerPrefixes, func(s string) bool { return strings.HasPrefix(entry.Manager, s) }) || entry.Subresource != "" {
+		if entry.Subresource != "" {
+			entries = append(entries, entry)
+			continue
+		}
+		if entry.Manager != manager && !slices.Any(managerPrefixes, func(s string) bool { return strings.HasPrefix(entry.Manager, s) }) {
 			entries = append(entries, entry)
 			continue
 		}


### PR DESCRIPTION
This PR fixes the handling of field owners in case of update policy `ssa-merge` or `ssa-override`.

Whenever an object is created by `Create()` (POST) or updated by `Update()` (PUT), the field ownership will be recorded with operation type `Update`. However, any ssa (PATCH) request (may it be creating or updating the object) will be recorded with operation type `Apply`. Where the API server considers these to records as different owners.

So the inconsistencies described in #81 can actually happen whenever, during the lifetime of an object, POST/PUT and ssa-PATCH are mixed.  This PR addresses this in two ways:

1. In the `replaceFieldManager()` function, also our own field records from `Update` operations (manager == ourselves, operation == Update) are reclaimed; and this happens in any ssa update.
2. To reduce the number of situations, where the resulting prepare patch call is required, we use now ssa-PATCH also to create the object, if update-policy is `ssa-merge` or `ssa-override`.