### PR TITLE
Refactor kustomize-generator options

### DIFF
--- a/pkg/manifests/kustomize/util.go
+++ b/pkg/manifests/kustomize/util.go
@@ -1,0 +1,12 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and component-operator-runtime contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kustomize
+
+// TODO: consolidate all the util files into an internal reuse package
+
+func ref[T any](x T) *T {
+	return &x
+}


### PR DESCRIPTION
This PR contains incompatible changes:
- Options for the kustomize generator are now passed via a new struct `KustomizeGeneratorOptions`
  ```go
  type KustomizeGeneratorOptions struct {
	  // If defined, only files with that suffix will be subject to templating.
	  TemplateSuffix *string
	  // If defined, the given left delimiter will be used to parse go templates; otherwise, defaults to '{{'
	  LeftTemplateDelimiter *string
	  // If defined, the given right delimiter will be used to parse go templates; otherwise, defaults to '}}'
	  RightTemplateDelimiter *string
  }
  ```
  The signature of the generator's `New*()` methods changes accordingly.
  Besides providing a suffix for files subject to templating, it is now possible to specify non-standard template delimiters (i.e. something different from `{{` and `}}`). In addition, options supplied through the constructors can be overridden in the source, if there exists a file `.component-config.yaml` at the kustomization's root directory.
- The implicit kustomization (i.e. the one which is auto-generated by the framework in case there is none) now ignores hidden files, i.e. files starting with a dot.