### PR TITLE
never delete dependents that is not owned by current component

### DIFF
--- a/clm/cmd/delete.go
+++ b/clm/cmd/delete.go
@@ -54,6 +54,8 @@ func newDeleteCmd() *cobra.Command {
 
 			releaseClient := release.NewClient(fullName, clnt)
 
+			ownerId := fullName + "/" + namespace + "/" + name
+
 			release, err := releaseClient.Get(context.TODO(), namespace, name)
 			if err != nil {
 				return err
@@ -94,7 +96,7 @@ func newDeleteCmd() *cobra.Command {
 
 			for {
 				release.State = component.StateDeleting
-				ok, err := reconciler.Delete(context.TODO(), &release.Inventory)
+				ok, err := reconciler.Delete(context.TODO(), &release.Inventory, ownerId)
 				if err != nil {
 					if !isEphmeralError(err) || errCount >= maxErrCount {
 						return err

--- a/pkg/component/target.go
+++ b/pkg/component/target.go
@@ -74,9 +74,10 @@ func (t *reconcileTarget[T]) Apply(ctx context.Context, component T) (bool, stri
 
 func (t *reconcileTarget[T]) Delete(ctx context.Context, component T) (bool, error) {
 	// log := log.FromContext(ctx)
+	ownerId := t.reconcilerId + "/" + component.GetNamespace() + "/" + component.GetName()
 	status := component.GetStatus()
 
-	return t.reconciler.Delete(ctx, &status.Inventory)
+	return t.reconciler.Delete(ctx, &status.Inventory, ownerId)
 }
 
 func (t *reconcileTarget[T]) IsDeletionAllowed(ctx context.Context, component T) (bool, string, error) {


### PR DESCRIPTION
This PR introduces owner-id validation upon deletion of objects.

So far, if objects in the component's inventory are deleted (because they become obsolete during apply, or the whole component gets deleted), that will be happening without considering the existing object's owner id. 

This is a bit dangerous and is changed now. If a dependent object is to be deleted but has a different or no owner, the deletion is rejected.