### PR TITLE
rework deletion policy

### DIFF
--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -75,8 +75,13 @@ type DeletePolicy string
 const (
 	// Delete dependent objects.
 	DeletePolicyDelete DeletePolicy = "Delete"
-	// Orphan dependent objects.
+	// Orphan dependent objects; that is, always, both if they become redundant when the component is applied,
+	// and if the component is deleted.
 	DeletePolicyOrphan DeletePolicy = "Orphan"
+	// Orphan dependent objects if they become redundant when the compponent is applied.
+	DeletePolicyOrphanOnApply DeletePolicy = "OrphanOnApply"
+	// Orphan dependent objects if the component is deleted.
+	DeletePolicyOrphanOnDelete DeletePolicy = "OrphanOnDelete"
 )
 
 // MissingNamespacesPolicy defines what the reconciler does if namespaces of dependent objects are not existing.

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -40,9 +40,11 @@ const (
 )
 
 const (
-	DeletePolicyDefault = "default"
-	DeletePolicyDelete  = "delete"
-	DeletePolicyOrphan  = "orphan"
+	DeletePolicyDefault        = "default"
+	DeletePolicyDelete         = "delete"
+	DeletePolicyOrphan         = "orphan"
+	DeletePolicyOrphanOnApply  = "orphan-on-apply"
+	DeletePolicyOrphanOnDelete = "orphan-on-delete"
 )
 
 const (


### PR DESCRIPTION
## Incompatible changes

The semantics of deletion policy `Orphan` is slightly changed; previously `Orphan` had no effect if a dependent object became redundant during apply (that is, it was part of the component manifest before, and is no longer now). Now, if an object has an effective deletion policy `Orphan`, then it will be always orphaned if
- the object becomes redundant during apply or
- the component itself is deleted.

## Enhancements

To allow more fine-granular control over the orphan behaviour, there are two new deletion policy values: `OrphanOnApply` and `OrphanOnDelete`, with the obvious meaning.