### PR TITLE
replace <no value> with empty string in all template outputs

### DIFF
--- a/internal/helm/chart.go
+++ b/internal/helm/chart.go
@@ -362,7 +362,7 @@ func (c *Chart) render(name string, t0 *template.Template, capabilities *Capabil
 				return nil, err
 			}
 
-			decoder := utilyaml.NewYAMLToJSONDecoder(&buf)
+			decoder := utilyaml.NewYAMLToJSONDecoder(bytes.NewBuffer(templatex.AdjustTemplateOutput(buf.Bytes())))
 			for {
 				object := &unstructured.Unstructured{}
 				if err := decoder.Decode(&object.Object); err != nil {

--- a/internal/templatex/functions.go
+++ b/internal/templatex/functions.go
@@ -249,15 +249,15 @@ func formatIPv4Address(data any) (string, error) {
 
 func makeFuncInclude(t *template.Template) func(string, any) (string, error) {
 	return func(name string, data any) (string, error) {
-		var buf strings.Builder
+		var buf bytes.Buffer
 		err := t.ExecuteTemplate(&buf, name, data)
-		return buf.String(), err
+		return string(AdjustTemplateOutput(buf.Bytes())), err
 	}
 }
 
 func makeFuncTpl(t *template.Template) func(string, any) (string, error) {
 	return func(text string, data any) (string, error) {
-		var buf strings.Builder
+		var buf bytes.Buffer
 		_t, err := t.Clone()
 		if err != nil {
 			// Clone() should never produce an error
@@ -268,7 +268,7 @@ func makeFuncTpl(t *template.Template) func(string, any) (string, error) {
 			return "", err
 		}
 		err = _t.Execute(&buf, data)
-		return buf.String(), err
+		return string(AdjustTemplateOutput(buf.Bytes())), err
 	}
 }
 

--- a/internal/templatex/util.go
+++ b/internal/templatex/util.go
@@ -1,0 +1,18 @@
+/*
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and component-operator-runtime contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package templatex
+
+import "bytes"
+
+// This function mimics the Helm behaviour. Background: values passed to the built-in generators
+// are of type map[string]any. Of course, templates are rendered with the missingkey=zero option.
+// But still, if a key is missing in the values, the empty value of 'any' (returned in this case)
+// makes the go templating engine return '<no value>' in that case.
+// Helm decided to override that by replacing all occurrences of the string '<no value>' in any template output
+// by the empty string. We are following that approach.
+func AdjustTemplateOutput(data []byte) []byte {
+	return bytes.ReplaceAll(data, []byte("<no value>"), []byte(""))
+}

--- a/pkg/manifests/kustomize/generator.go
+++ b/pkg/manifests/kustomize/generator.go
@@ -242,7 +242,7 @@ func (g *KustomizeGenerator) Generate(ctx context.Context, namespace string, nam
 		if err := t0.ExecuteTemplate(&buf, t.Name(), data); err != nil {
 			return nil, err
 		}
-		if err := fsys.WriteFile(n, buf.Bytes()); err != nil {
+		if err := fsys.WriteFile(n, templatex.AdjustTemplateOutput(buf.Bytes())); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/manifests/transformer.go
+++ b/pkg/manifests/transformer.go
@@ -65,7 +65,7 @@ func (t *TemplateParameterTransformer) TransformParameters(namespace string, nam
 		return nil, err
 	}
 	var transformedParameters types.UnstructurableMap
-	if err := kyaml.Unmarshal(buf.Bytes(), &transformedParameters); err != nil {
+	if err := kyaml.Unmarshal(templatex.AdjustTemplateOutput(buf.Bytes()), &transformedParameters); err != nil {
 		return nil, err
 	}
 	return transformedParameters, nil


### PR DESCRIPTION
This PR changes the template rendering. 

Background: values passed to the built-in generators and transformers
are of type map[string]any. Of course, templates are rendered with the `missingkey=zero` option.
But still, if a key is missing in the values, the empty value of `any` (returned in this case)
makes the go templating engine return `<no value>` in that case.

Helm decided to override that by replacing all occurrences of the string `<no value>` in any template output.
Starting with this PR we adopt the helm approach, and do the same.