### PR TITLE
deduplicate subsequent component events

### DIFF
--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -1,0 +1,78 @@
+/*
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and component-operator-runtime contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package events
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DeduplicatingRecorder struct {
+	recorder record.EventRecorder
+	mutex    sync.Mutex
+	events   map[string]event
+}
+
+type event struct {
+	digest    string
+	timestamp time.Time
+}
+
+func NewDeduplicatingRecorder(recorder record.EventRecorder) *DeduplicatingRecorder {
+	return &DeduplicatingRecorder{
+		recorder: recorder,
+		events:   make(map[string]event),
+	}
+}
+
+func (r *DeduplicatingRecorder) Event(object client.Object, eventType string, reason string, message string) {
+	if r.isDuplicate(object, nil, eventType, reason, message) {
+		return
+	}
+	r.recorder.Event(object, eventType, reason, message)
+}
+
+func (r *DeduplicatingRecorder) Eventf(object client.Object, eventType string, reason string, messageFmt string, args ...any) {
+	if r.isDuplicate(object, nil, eventType, reason, fmt.Sprintf(messageFmt, args...)) {
+		return
+	}
+	r.recorder.Eventf(object, eventType, reason, messageFmt, args...)
+}
+
+func (r *DeduplicatingRecorder) AnnotatedEventf(object client.Object, annotations map[string]string, eventType string, reason string, messageFmt string, args ...any) {
+	if r.isDuplicate(object, annotations, eventType, reason, fmt.Sprintf(messageFmt, args...)) {
+		return
+	}
+	r.recorder.AnnotatedEventf(object, annotations, eventType, reason, messageFmt, args...)
+}
+
+func (r *DeduplicatingRecorder) isDuplicate(object client.Object, annotations map[string]string, eventType, reason, message string) bool {
+	uid := string(object.GetUID())
+	digest := calculateDigest(annotations, eventType, reason, message)
+	now := time.Now()
+	exp := time.Now().Add(-5 * time.Minute)
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	for uid, event := range r.events {
+		if event.timestamp.Before(exp) {
+			delete(r.events, uid)
+		}
+	}
+	if r.events[uid].digest == digest {
+		return true
+	} else {
+		r.events[uid] = event{
+			digest:    digest,
+			timestamp: now,
+		}
+		return false
+	}
+}

--- a/internal/events/util.go
+++ b/internal/events/util.go
@@ -1,0 +1,31 @@
+/*
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and component-operator-runtime contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package events
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+// TODO: consolidate all the util files into an internal reuse package
+
+func must[T any](x T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return x
+}
+
+func sha256hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func calculateDigest(values ...any) string {
+	// note: this must() is ok because the input values are expected to be JSON values
+	return sha256hex(must(json.Marshal(values)))
+}


### PR DESCRIPTION
This PR optimizes the event sending logic.

So far, the framework emitted really many events, mostly in the `Processing` state. That often exceeded the burst of the event broadcaster provided by controller-runtime (b=25, r=1/300, see https://github.com/kubernetes/client-go/blob/b46275ad754db4dd7695a48cd3ca673e0154dd9e/tools/record/events_cache.go#L43).

We change that now. If there are identical subsequent events produced for an object, only the first one will be emitted within 5 minutes; after 5 minutes, again one instance of the event may be sent, and so on.