### PR TITLE
avoid unnecessary first restarting loop

### DIFF
--- a/pkg/component/target.go
+++ b/pkg/component/target.go
@@ -66,9 +66,7 @@ func (t *reconcileTarget[T]) Apply(ctx context.Context, component T, componentDi
 		return false, errors.Wrap(err, "error rendering manifests")
 	}
 
-	ok, err := t.reconciler.Apply(ctx, &status.Inventory, objects, namespace, ownerId, componentDigest)
-
-	return ok, err
+	return t.reconciler.Apply(ctx, &status.Inventory, objects, namespace, ownerId, componentDigest)
 }
 
 func (t *reconcileTarget[T]) Delete(ctx context.Context, component T) (bool, error) {


### PR DESCRIPTION
So far, status was set to `Restarting`, and an immediate requeue was triggered whenever the component digest changed. This happened also if `status.ProcessingDigest` was empty (which happens only at the very beginning of the life of a component, because - once set - the field `status.ProcessingDigest` gets never cleared). But this requeue is unnecessary, and the event emitted due to the status change causes unwanted noise. Therefore we optimize that, and avoid that requeue/restarting if `status.ProcessingDigest` is empty.