### PR TITLE
fix empty kustomization.yaml error

### DIFF
--- a/pkg/manifests/kustomize/generator.go
+++ b/pkg/manifests/kustomize/generator.go
@@ -394,6 +394,11 @@ func generateKustomization(fsys kustfsys.FileSystem) ([]byte, error) {
 		Resources: resources,
 	}
 
+	if len(resources) == 0 {
+		// if there are no resources, set a dummy namespace to avoid "kustomization.yaml is empty" build error
+		kustomization.Namespace = "_dummy"
+	}
+
 	rawKustomization, err := kyaml.Marshal(kustomization)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If an empty kustomization is generated (that is: `Resources == []`, the serialized output is missing the `resources` attribute because of an `omitempty` tag in the API definition. Unfortunately kustomize rejects such a `kustomization.yaml` with an error "kustomization.yaml is empty". As a workaround, when the framework auto-generates a `kustomization.yaml` without any resources, we set a dummy namespace in the `kustomization.yaml` (this is - btw- the same workaround that is implemented by flux).