### PR TITLE
Allow to suppress events via annotation

### DIFF
--- a/pkg/component/reconciler.go
+++ b/pkg/component/reconciler.go
@@ -911,6 +911,10 @@ func (r *Reconciler[T]) getOptionsForComponent(component T) reconciler.Reconcile
 			options.ReapplyInterval = &reapplyInterval
 		}
 	}
+	// TODO: formalize the following into a Configuration interface?
+	if component.GetAnnotations()[r.name+"/"+types.AnnotationKeySuffixDisableEvents] == "true" {
+		options.EnableEvents = ref(false)
+	}
 	return options
 }
 

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -18,6 +18,7 @@ const (
 	AnnotationKeySuffixPurgeOrder      = "purge-order"
 	AnnotationKeySuffixDeleteOrder     = "delete-order"
 	AnnotationKeySuffixStatusHint      = "status-hint"
+	AnnotationKeySuffixDisableEvents   = "disable-events"
 )
 
 const (


### PR DESCRIPTION
This PR adds the options to suppress emitting events on dependent objects by setting the annotation

```yaml
<operator name>/disable-events: "true"
```

on the component.

This helps in some cases where a remote kubeconfig or service account is used, which does not have the necessary RBAC permissions to write events in the target.

In a later phase, we might formalize this annotation into a `Configuration` interface.