### PR TITLE
chore(ci): declare explicit permissions for read-default rollout

### DIFF
--- a/.github/workflows/publish-clm.yaml
+++ b/.github/workflows/publish-clm.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/publish-scaffold.yaml
+++ b/.github/workflows/publish-scaffold.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## What

Declare explicit `permissions: contents: write` on the two release-asset upload workflows so they keep working after the org-wide flip to read-default `GITHUB_TOKEN`.

Workflows touched:
- `.github/workflows/publish-clm.yaml`
- `.github/workflows/publish-scaffold.yaml`

## Why

OSPO hardening — Finding 1: `restrict_default_workflow_permissions = true` will be enabled fleet-wide on the SAP CS-DevOps OSPO repo set. Both workflows upload binaries to the release via `curl -H "Authorization: Bearer \${{ secrets.GITHUB_TOKEN }}"` to `upload_url`. Asset upload requires `contents: write`; without it the curl will 403 under the read-only default.

## Risk

Low. Token scope is narrowed (was implicit write-everything; becomes `contents: write` only). Behavior unchanged on the happy path.

## Test plan

- [ ] Next real release publishes both `clm-*` and the scaffold archive without 403.