### PR TITLE
clm: fix path handling for single files; and cleanup os.IsNotExist() usage

### DIFF
--- a/clm/internal/manifests/generate.go
+++ b/clm/internal/manifests/generate.go
@@ -57,7 +57,7 @@ func Generate(manifestSources []string, valuesSources []string, reconcilerName s
 		}
 
 		if info, err := os.Stat(source); err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return nil, fmt.Errorf("no such file or directory: %s", source)
 			} else {
 				return nil, err
@@ -75,7 +75,7 @@ func Generate(manifestSources []string, valuesSources []string, reconcilerName s
 				return nil, err
 			}
 			fsys = os.DirFS(tmpdir)
-			path = ""
+			path = "."
 		}
 
 		var generator manifests.Generator


### PR DESCRIPTION
Two changes in here:
- Fix path handling in case a provided source is a (single) file.
- According to https://pkg.go.dev/os#IsNotExist, `errors.Is(err, fs.ErrNotExist)` should be used instead.